### PR TITLE
Add default_optlib to exported API

### DIFF
--- a/src/DensityRatioEstimation.jl
+++ b/src/DensityRatioEstimation.jl
@@ -56,6 +56,7 @@ export
   # estimators
   DensityRatioEstimator,
   KMM, KLIEP,
+  default_optlib,
   densratiofunc,
   densratio,
 

--- a/src/api/estimators.jl
+++ b/src/api/estimators.jl
@@ -27,7 +27,7 @@ the list below:
 See also [`densratiofunc`](@ref).
 """
 densratio(x_nu, x_de, dre::DensityRatioEstimator;
-          optlib=_default_optlib(typeof(dre))) =
+          optlib=default_optlib(typeof(dre))) =
   _densratio(x_nu, x_de, dre, optlib)
 
 """
@@ -45,8 +45,18 @@ Only some estimators define a ratio function that can
 be evaluated outside `x_de`.
 """
 densratiofunc(x_nu, x_de, dre::DensityRatioEstimator;
-              optlib=_default_optlib(typeof(dre))) =
+              optlib=default_optlib(typeof(dre))) =
   _densratiofunc(x_nu, x_de, dre, optlib)
+
+"""
+    default_optlib(dre)
+
+Return default optimization library for density ratio
+estimator `dre`. The function can also be called on the
+type `typeof(dre)`.
+"""
+default_optlib(dre::DensityRatioEstimator) =
+  default_optlib(typeof(dre))
 
 ###################################################
 ## functions to be implemented by new estimators ##
@@ -60,5 +70,5 @@ _densratiofunc(x_nu, x_de, dre::DensityRatioEstimator,
                optlib::Type{OptimizationLibrary}) =
   @error "not implemented"
 
-_default_optlib(dre::Type{DensityRatioEstimator}) =
+default_optlib(dre::Type{DensityRatioEstimator}) =
   @error "not implemented"

--- a/src/kliep.jl
+++ b/src/kliep.jl
@@ -26,7 +26,7 @@ Kullback-Leibler importance estimation procedure (KLIEP).
   b::Int=100
 end
 
-_default_optlib(dre::Type{<:KLIEP}) = OptimLib
+default_optlib(dre::Type{<:KLIEP}) = OptimLib
 
 function _densratio(x_nu, x_de, dre::KLIEP,
                     optlib::Type{<:OptimizationLibrary})

--- a/src/kmm.jl
+++ b/src/kmm.jl
@@ -29,4 +29,4 @@ Kernel Mean Matching (KMM).
   λ::T=0.0
 end
 
-_default_optlib(dre::Type{<:KMM}) = JuMPLib
+default_optlib(dre::Type{<:KMM}) = JuMPLib


### PR DESCRIPTION
This PR renames the internal `_default_optlib` function to `default_optlib` and exports it as part of the user API. This has shown to be important in use cases where users may be interested in choosing a default for the estimator they've selected.

I've also added a new method for the function to work directly on estimator instances. We can call `default_optlib(dre)` and `default_optlib(typeof(dre))`.

Appreciate if you can review/merge.