### PR TITLE
Change meaning of parameter b in KLIEP

### DIFF
--- a/src/kliep.jl
+++ b/src/kliep.jl
@@ -10,7 +10,7 @@ Kullback-Leibler importance estimation procedure (KLIEP).
 ## Parameters
 
 * `σ` - Bandwidth of Gaussian kernel (default to `1.0`)
-* `b` - Number of radial basis functions (default to `100`)
+* `b` - Maximum number of radial basis functions (default to `100`)
 
 ## References
 
@@ -55,10 +55,8 @@ in kernel approximation of density ratio function.
 function _kliep_centers(x_nu, dre::KLIEP)
   b = dre.b
   n = length(x_nu)
-
-  @assert b ≤ n "more basis elements than numerator samples"
-
-  sample(1:n, b, replace=false)
+  s = min(n, b)
+  sample(1:n, s, replace=false)
 end
 
 """

--- a/src/kliep/convex.jl
+++ b/src/kliep/convex.jl
@@ -8,7 +8,7 @@ import .ECOS: ECOSSolver
 function _kliep_coeffs(x_nu, x_de, centers::AbstractVector{Int},
                        dre::KLIEP, optlib::Type{ConvexLib})
   # retrieve parameters
-  @unpack σ, b = dre
+  σ, b = dre.σ, length(centers)
 
   # number of numerator and denominator samples
   n_nu, n_de = length(x_nu), length(x_de)

--- a/src/kliep/optim.jl
+++ b/src/kliep/optim.jl
@@ -7,7 +7,7 @@ using .Optim
 function _kliep_coeffs(x_nu, x_de, centers::AbstractVector{Int},
                        dre::KLIEP, optlib::Type{OptimLib})
   # retrieve parameters
-  @unpack σ, b = dre
+  σ, b = dre.σ, length(centers)
 
   # number of numerator and denominator samples
   n_nu, n_de = length(x_nu), length(x_de)


### PR DESCRIPTION
This PR changes the meaning of the parameter `b` in KLIEP to be the maximum number as opposed to the exact number. This is more useful in practice where the user doesn't know a priori the number of samples available.